### PR TITLE
Change Droplet _drpKernel field to be "Maybe"

### DIFF
--- a/src/Net/DigitalOcean/Droplets.hs
+++ b/src/Net/DigitalOcean/Droplets.hs
@@ -142,7 +142,7 @@ data Droplet = Droplet
                , _drpRegion :: Maybe Region
                , _drpImage :: Maybe Image
                , _drpNetworks :: [Network]
-               , _drpKernel :: Kernel
+               , _drpKernel :: Maybe Kernel
                } deriving (Show, Eq)
 makeLenses ''Droplet
 


### PR DESCRIPTION
The official DigitalOcean API docs[1] say that the "kernel" field of a
droplet is a "nullable object". From testing it appears that for some
droplets it does indeed return `null`. Changing to "Maybe" allows proper
parsing of the JSON (without throwing an exception)

[1] https://developers.digitalocean.com/documentation/v2/
